### PR TITLE
Remove stale links to removed sections

### DIFF
--- a/order-review.html
+++ b/order-review.html
@@ -52,8 +52,6 @@
 <div class="flex items-center gap-4">
 <nav class="hidden md:flex items-center gap-6">
 <a class="text-sm font-medium text-black/60 dark:text-white/60 hover:text-black dark:hover:text-white transition-colors" href="index.html#menu">Menu</a>
-<a class="text-sm font-medium text-black/60 dark:text-white/60 hover:text-black dark:hover:text-white transition-colors" href="index.html#how-it-works">About</a>
-<a class="text-sm font-medium text-black/60 dark:text-white/60 hover:text-black dark:hover:text-white transition-colors" href="index.html#contact">Contact</a>
 </nav>
 <button class="flex items-center justify-center gap-2 rounded-lg bg-primary/20 dark:bg-primary/30 h-10 px-4 text-sm font-bold text-black dark:text-white hover:bg-primary/30 dark:hover:bg-primary/40 transition-colors">
 <span class="material-symbols-outlined text-base">shopping_cart</span>


### PR DESCRIPTION
## Summary
- remove the About and Contact navigation links from the order review header so it only points to the Menu section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df612f07448333a0e948a553f8fb43