### PR TITLE
Add pickup or delivery selection to order form

### DIFF
--- a/order-review.html
+++ b/order-review.html
@@ -84,6 +84,29 @@
             <label class="block text-sm font-medium text-black/80 dark:text-white/80 mb-1" for="phone">Phone <span class="text-primary dark:text-white">*</span></label>
             <input class="block w-full rounded-lg border-black/20 dark:border-white/20 bg-background-light dark:bg-background-dark focus:ring-primary focus:border-primary placeholder:text-black/40 dark:placeholder:text-white/40" id="phone" name="phone" pattern="[0-9]{2,3}\s[0-9]{3}\s[0-9]{4,}" placeholder="e.g. 021 123 4567" required type="tel" />
           </div>
+          <fieldset class="space-y-3">
+            <legend class="block text-sm font-medium text-black/80 dark:text-white/80">Pickup or delivery <span class="text-primary dark:text-white">*</span></legend>
+            <div class="space-y-2" role="radiogroup" aria-required="true">
+              <label class="flex items-start gap-3 text-sm text-black/80 dark:text-white/80">
+                <input checked class="mt-1 h-4 w-4 rounded border-black/30 dark:border-white/30 text-primary focus:ring-primary" data-fulfillment-option="pickup" id="fulfillment-pickup" name="fulfillment" type="radio" value="pickup" />
+                <span>
+                  <span class="font-medium text-black dark:text-white">Pickup</span>
+                  <span class="block text-black/60 dark:text-white/60">Collect your order from our kitchen at the scheduled time.</span>
+                </span>
+              </label>
+              <label class="flex items-start gap-3 text-sm text-black/60 dark:text-white/60 cursor-not-allowed" aria-disabled="true">
+                <input aria-describedby="delivery-coming-soon" class="mt-1 h-4 w-4 rounded border-black/30 dark:border-white/30 text-primary focus:ring-primary" data-fulfillment-option="delivery" disabled id="fulfillment-delivery" name="fulfillment" type="radio" value="delivery" />
+                <span>
+                  <span class="font-medium">Delivery</span>
+                  <span class="block" id="delivery-coming-soon">Home delivery is coming soon. Stay tuned!</span>
+                </span>
+              </label>
+            </div>
+          </fieldset>
+          <div class="space-y-2 hidden" data-delivery-address-field>
+            <label class="block text-sm font-medium text-black/80 dark:text-white/80" for="delivery-address">Delivery address <span class="text-primary dark:text-white">*</span></label>
+            <input aria-describedby="delivery-coming-soon" class="block w-full rounded-lg border-black/20 dark:border-white/20 bg-background-light dark:bg-background-dark focus:ring-primary focus:border-primary placeholder:text-black/40 dark:placeholder:text-white/40" data-delivery-address-input id="delivery-address" name="delivery-address" placeholder="e.g. 123 Curry Lane, Wellington" type="text" disabled />
+          </div>
           <div>
             <label class="block text-sm font-medium text-black/80 dark:text-white/80 mb-1" for="notes">Notes</label>
             <textarea class="block w-full rounded-lg border-black/20 dark:border-white/20 bg-background-light dark:bg-background-dark focus:ring-primary focus:border-primary placeholder:text-black/40 dark:placeholder:text-white/40" id="notes" name="notes" placeholder="Any dietary requirements or special requests?" rows="3"></textarea>

--- a/scripts/order-review.js
+++ b/scripts/order-review.js
@@ -65,8 +65,47 @@ export function initializeOrderReviewPage({ window }) {
   const cartSummaryText = document.querySelector('[data-cart-summary-text]');
   const cartLink = document.querySelector('[data-cart-link]');
   const placeOrderButton = document.querySelector('[data-place-order]');
+  const customerForm = document.querySelector('[data-customer-form]');
+  const fulfillmentOptions = customerForm
+    ? Array.from(customerForm.querySelectorAll('[data-fulfillment-option]'))
+    : [];
+  const deliveryAddressField = customerForm?.querySelector('[data-delivery-address-field]');
+  const deliveryAddressInput = customerForm?.querySelector('[data-delivery-address-input]');
 
   const serviceFee = getServiceFee(serviceFeeElement);
+
+  const updateFulfillmentState = (selectedValue) => {
+    const isDelivery = selectedValue === 'delivery';
+
+    if (deliveryAddressField) {
+      deliveryAddressField.classList.toggle('hidden', !isDelivery);
+    }
+
+    if (deliveryAddressInput) {
+      if (isDelivery) {
+        deliveryAddressInput.removeAttribute('disabled');
+        deliveryAddressInput.setAttribute('required', '');
+        deliveryAddressInput.setAttribute('aria-required', 'true');
+      } else {
+        deliveryAddressInput.setAttribute('disabled', '');
+        deliveryAddressInput.removeAttribute('required');
+        deliveryAddressInput.removeAttribute('aria-required');
+      }
+    }
+  };
+
+  if (fulfillmentOptions.length > 0) {
+    const initiallyChecked = fulfillmentOptions.find((input) => input.checked) ?? fulfillmentOptions[0];
+    updateFulfillmentState(initiallyChecked?.value ?? 'pickup');
+
+    fulfillmentOptions.forEach((input) => {
+      input.addEventListener('change', () => {
+        updateFulfillmentState(input.value);
+      });
+    });
+  } else {
+    updateFulfillmentState('pickup');
+  }
 
   function updateSummary() {
     const { totalQuantity, subtotal } = calculateCartTotals(cartItems);

--- a/tests/order-review.test.js
+++ b/tests/order-review.test.js
@@ -82,8 +82,13 @@ class FakeElement extends FakeEventTarget {
   }
 
   querySelector(selector) {
-    if (this.named[selector]) {
-      return this.named[selector];
+    const namedMatch = this.named[selector];
+    if (Array.isArray(namedMatch)) {
+      return namedMatch[0] ?? null;
+    }
+
+    if (namedMatch) {
+      return namedMatch;
     }
     for (const child of this.children) {
       const match = child.querySelector(selector);
@@ -96,8 +101,11 @@ class FakeElement extends FakeEventTarget {
 
   querySelectorAll(selector) {
     const results = [];
-    if (this.named[selector]) {
-      results.push(this.named[selector]);
+    const namedMatch = this.named[selector];
+    if (Array.isArray(namedMatch)) {
+      results.push(...namedMatch);
+    } else if (namedMatch) {
+      results.push(namedMatch);
     }
     for (const child of this.children) {
       results.push(...child.querySelectorAll(selector));
@@ -265,4 +273,80 @@ test('order review renders stored cart items and updates summary', () => {
   strictEqual(placeOrder.hasOwnProperty('attributes') && 'aria-disabled' in placeOrder.attributes, false);
 
   ok(emptyState.classList.contains('hidden'));
+});
+
+test('fulfillment selection toggles delivery address requirements', () => {
+  const itemsContainer = new FakeElement();
+  const emptyState = new FakeElement({ classNames: ['hidden'] });
+  const cartSummaryText = new FakeElement();
+  const cartCount = new FakeElement({ classNames: ['hidden'] });
+  const cartLink = new FakeElement();
+  const subtotal = new FakeElement();
+  const serviceFee = new FakeElement({ dataset: { fee: '2' }, textContent: '$2.00' });
+  const total = new FakeElement();
+  const placeOrder = new FakeElement({ classNames: ['pointer-events-none', 'opacity-70'] });
+  placeOrder.attributes['aria-disabled'] = 'true';
+  const template = new FakeTemplate();
+
+  const customerForm = new FakeElement();
+  const pickupRadio = new FakeElement();
+  pickupRadio.value = 'pickup';
+  pickupRadio.checked = true;
+
+  const deliveryRadio = new FakeElement();
+  deliveryRadio.value = 'delivery';
+
+  const addressField = new FakeElement({ classNames: ['hidden'] });
+  const addressInput = new FakeElement();
+  addressInput.attributes.disabled = '';
+
+  customerForm.named['[data-fulfillment-option]'] = [pickupRadio, deliveryRadio];
+  customerForm.named['[data-delivery-address-field]'] = addressField;
+  customerForm.named['[data-delivery-address-input]'] = addressInput;
+
+  const document = new FakeDocument({
+    '[data-cart-items]': itemsContainer,
+    '[data-empty-state]': emptyState,
+    '#cart-item-template': template,
+    '[data-summary-subtotal]': subtotal,
+    '[data-summary-total]': total,
+    '[data-service-fee]': serviceFee,
+    '[data-cart-count]': cartCount,
+    '[data-cart-summary-text]': cartSummaryText,
+    '[data-cart-link]': cartLink,
+    '[data-place-order]': placeOrder,
+    '[data-customer-form]': customerForm,
+  });
+
+  const window = {
+    document,
+    localStorage: new MemoryStorage(),
+    setTimeout(fn) {
+      fn();
+      return 1;
+    },
+  };
+
+  initializeOrderReviewPage({ window });
+
+  ok(addressField.classList.contains('hidden'));
+  ok('disabled' in addressInput.attributes);
+  ok(!('required' in addressInput.attributes));
+
+  pickupRadio.checked = false;
+  deliveryRadio.checked = true;
+  deliveryRadio.dispatchEvent({ type: 'change' });
+
+  ok(!addressField.classList.contains('hidden'));
+  ok(!('disabled' in addressInput.attributes));
+  strictEqual(addressInput.attributes.required, '');
+  strictEqual(addressInput.attributes['aria-required'], 'true');
+
+  deliveryRadio.checked = false;
+  pickupRadio.checked = true;
+  pickupRadio.dispatchEvent({ type: 'change' });
+
+  ok(addressField.classList.contains('hidden'));
+  ok('disabled' in addressInput.attributes);
+  ok(!('required' in addressInput.attributes));
 });


### PR DESCRIPTION
## Summary
- add pickup and delivery radio options to the order review customer details form
- keep delivery disabled while preparing delivery address input for future use
- toggle delivery address requirements in the order review script and cover with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5fd8dd7948333a9ed5a6f75913ff8